### PR TITLE
Fix UTF-8 encoding problem

### DIFF
--- a/rt_client.rb
+++ b/rt_client.rb
@@ -879,7 +879,7 @@ class RT_Client
   # Helper to replace control characters with string representations
   # When some XML libraries hit these in an XML response, bad things happen.
   def sterilize(str)
-      str.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      str.encode!('UTF-8', str.encoding.to_s, invalid: :replace, undef: :replace, replace: '')
       str.gsub!(0x00.chr,'[NUL]')
       str.gsub!(0x01.chr,'[SOH]')
       str.gsub!(0x02.chr,'[STX]')


### PR DESCRIPTION
Don't convert any unknown encoding from binary to UTF-8. This breaks some chars if the str is already UTF-8, e.g. german umlauts.